### PR TITLE
fix: productOptions

### DIFF
--- a/utils/ProductOperationHandler.js
+++ b/utils/ProductOperationHandler.js
@@ -42,7 +42,12 @@ class ProductOperationHandler {
       handle: product.handle,
       status: product.status || 'ACTIVE',
       tags: product.tags,
-      options: product.options.map(opt => opt.name)
+      productOptions: product.options.map(opt => {
+        return {
+          name: opt.name,
+          values: opt.values.map(value => ({ name: value }))
+        };
+      })
       // Don't include variants directly as we'll use productVariantsBulkCreate for better control
     };
 


### PR DESCRIPTION
As the code base is using type `{Object}` a lot I'm not completely positive that this is correct, but [ProductInput](https://shopify.dev/docs/api/admin-graphql/latest/input-objects/ProductInput) doesn't have a "options" property, so I assume this should take the correct form of "productOptions"?