### PR TITLE
Refactor logger indentation usage

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -157,12 +157,11 @@ class MetaSyncCli {
     // Check if resource type was provided
     if (!this.options.resource) {
       logger.newline();
-      logger.info(chalk.bold("Available resource types:"));
-      logger.indent();
+      logger.startSection(chalk.bold("Available resource types:"));
       validResourceTypes.forEach(type => {
         logger.info(`${chalk.cyan(type)}`, 0, 'main');
       });
-      logger.unindent();
+      logger.endSection();
       logger.newline();
       logger.info(`Specify the resource type with ${chalk.yellow('--resource <type>')} option`);
       logger.info(`Example: ${chalk.green('metasync definitions metafields --resource products --namespace custom')}`);
@@ -266,10 +265,7 @@ class MetaSyncCli {
 
     // Use blank line and proper indentation with blank line after
     logger.newline();
-    logger.info(`Available metaobject definition types:`);
-
-    // Increase indentation level before listing types
-    logger.indent();
+    logger.startSection(`Available metaobject definition types:`);
 
     definitions.forEach(def => {
       // Using 'main' type for info to get the bullet point
@@ -277,7 +273,7 @@ class MetaSyncCli {
     });
 
     // Reset indentation after the list
-    logger.unindent();
+    logger.endSection();
   }
 
   async _listMetafieldDefinitions() {
@@ -307,9 +303,7 @@ class MetaSyncCli {
       // Process each resource type
       for (const resourceType of metafieldResourceTypes) {
         // Log the resource type
-        logger.section(`RESOURCE TYPE: ${resourceType.toUpperCase()}`);
-
-        logger.indent();
+        logger.startSection(`RESOURCE TYPE: ${resourceType.toUpperCase()}`);
 
         // Get the strategy for this resource type
         const ResourceStrategyClass = strategyLoader.getDefinitionStrategyForResource(resourceType);
@@ -337,8 +331,8 @@ class MetaSyncCli {
           logger.warn(`No sync strategy available for ${resourceType} definitions.`);
         }
 
-        // Unindent after this resource type is done
-        logger.unindent();
+        // End section for this resource type
+        logger.endSection();
       }
 
       return { definitionResults: combinedResults, dataResults: null };

--- a/strategies/BaseMetafieldSyncStrategy.js
+++ b/strategies/BaseMetafieldSyncStrategy.js
@@ -176,12 +176,11 @@ class BaseMetafieldSyncStrategy {
 
         // Log the GraphQL errors if available
         if (error.graphQLErrors && error.graphQLErrors.length) {
-          logger.error('GraphQL API errors:');
-          logger.indent();
+          logger.startSection('GraphQL API errors:');
           error.graphQLErrors.forEach(err => {
             logger.error(err.message);
           });
-          logger.unindent();
+          logger.endSection();
         }
 
         return null;
@@ -301,12 +300,11 @@ class BaseMetafieldSyncStrategy {
 
         // Log the GraphQL errors if available
         if (error.graphQLErrors && error.graphQLErrors.length) {
-          logger.error('GraphQL API errors:');
-          logger.indent();
+          logger.startSection('GraphQL API errors:');
           error.graphQLErrors.forEach(err => {
             logger.error(err.message);
           });
-          logger.unindent();
+          logger.endSection();
         }
 
         return null;
@@ -393,14 +391,13 @@ class BaseMetafieldSyncStrategy {
         return { results: { created: 0, updated: 0, skipped: 0, failed: 0, deleted: 0 }, definitionKeys: [] };
       }
 
-      logger.info(`Found ${targetDefinitions.length} definition(s) to delete in target.`);
+      logger.startSection(`Found ${targetDefinitions.length} definition(s) to delete in target.`);
 
       // Log each definition to be deleted
-      logger.indent();
       targetDefinitions.forEach(def => {
         logger.info(`${def.namespace}.${def.key} (${def.name || 'unnamed'}): ${def.type.name}`, 0, 'main');
       });
-      logger.unindent();
+      logger.endSection();
 
       const results = { created: 0, updated: 0, skipped: 0, failed: 0, deleted: 0 };
       let processedCount = 0;
@@ -415,10 +412,7 @@ class BaseMetafieldSyncStrategy {
         }
 
         const definitionFullKey = `${definition.namespace}.${definition.key}`;
-        logger.info(`Deleting ${this.resourceName} definition: ${definitionFullKey}`);
-
-        // Indent the dry run message to appear under the delete message
-        logger.indent();
+        logger.startSection(`Deleting ${this.resourceName} definition: ${definitionFullKey}`);
         const deleted = await this.deleteMetafieldDefinition(this.targetClient, definition);
 
         if (deleted) {
@@ -428,7 +422,7 @@ class BaseMetafieldSyncStrategy {
           results.failed++;
         }
 
-        logger.unindent();
+        logger.endSection();
 
         processedCount++;
       }
@@ -532,10 +526,7 @@ class BaseMetafieldSyncStrategy {
       const targetDefinition = targetDefinitionMap[definitionFullKey];
 
       if (targetDefinition) {
-        logger.info(`Updating ${this.resourceName} definition: ${chalk.bold(definitionFullKey)}`);
-
-        // Increase indentation for update operation and output
-        logger.indent();
+        logger.startSection(`Updating ${this.resourceName} definition: ${chalk.bold(definitionFullKey)}`);
 
         // Pass the potentially modified definitionToSync
         const updated = await this.updateMetafieldDefinition(this.targetClient, definitionToSync, targetDefinition);
@@ -547,12 +538,9 @@ class BaseMetafieldSyncStrategy {
           results.failed++;
         }
 
-        logger.unindent();
+        logger.endSection();
       } else {
-        logger.info(`Creating ${this.resourceName} definition: ${chalk.bold(definitionFullKey)}`);
-
-        // Increase indentation for create operation and output
-        logger.indent();
+        logger.startSection(`Creating ${this.resourceName} definition: ${chalk.bold(definitionFullKey)}`);
 
         // Pass the potentially modified definitionToSync
         const created = await this.createMetafieldDefinition(this.targetClient, definitionToSync);
@@ -568,7 +556,7 @@ class BaseMetafieldSyncStrategy {
           }
         }
 
-        logger.unindent();
+        logger.endSection();
       }
       processedCount++;
     }
@@ -607,16 +595,13 @@ class BaseMetafieldSyncStrategy {
     Object.keys(namespaceGroups).sort().forEach(namespace => {
       // Get current indent and log with purple color
       const indent = logger.getIndent();
-      logger.info(`Found Namespace: ${chalk.magenta.bold(`${namespace}`)}`);
-
-      // Increase indentation for contents under this namespace
-      logger.indent();
+      logger.startSection(`Found Namespace: ${chalk.magenta.bold(`${namespace}`)}`);
 
       namespaceGroups[namespace].forEach(def => {
         logger.info(`${def.key} (${def.name || "No name"})`);
       });
 
-      logger.unindent();
+      logger.endSection();
     });
 
     logger.info(`\nPlease run the command again with --namespace <namespace> to specify which ${this.resourceName} namespace to sync.`);
@@ -630,10 +615,7 @@ class BaseMetafieldSyncStrategy {
   async logNamespaceHeading(namespace) {
     // Get current indent and log with purple color
     const indent = logger.getIndent();
-    logger.info(`${indent}Found Namespace: ${chalk.magenta.bold(`${namespace}`)}`);
-
-    // Increase indentation for everything under this namespace
-    logger.indent();
+    logger.startSection(`Found Namespace: ${chalk.magenta.bold(`${namespace}`)}`);
   }
 
   async sync() {

--- a/strategies/ProductSyncStrategy.js
+++ b/strategies/ProductSyncStrategy.js
@@ -160,10 +160,9 @@ class ProductSyncStrategy {
     let deleteCount = 0;
     let failCount = 0;
 
-    logger.indent();
+    logger.startSection('Deleting products');
     for (const product of productsToDelete) {
-      logger.info(`Deleting product: ${product.title} (${product.handle})`);
-      logger.indent();
+      logger.startSection(`Deleting product: ${product.title} (${product.handle})`);
       logger.info(`Deleting product with ID: ${product.id}`);
 
       const deleted = await this.productHandler.deleteProduct(product.id);
@@ -176,9 +175,9 @@ class ProductSyncStrategy {
         failCount++;
         logger.error(`Failed to delete product: ${product.title}`);
       }
-      logger.unindent();
+      logger.endSection();
     }
-    logger.unindent();
+    logger.endSection();
 
     logger.success(`Finished delete operation.`);
     logger.info(`Deleted: ${deleteCount}, Failed: ${failCount}`);

--- a/utils/CollectionRuleSetHandler.js
+++ b/utils/CollectionRuleSetHandler.js
@@ -27,8 +27,7 @@ class CollectionRuleSetHandler {
     }
 
     // Log the whole ruleSet for debugging
-    logger.info(`Collection ruleSet details:`);
-    logger.indent();
+    logger.startSection(`Collection ruleSet details:`);
     logger.info(`Rules count: ${collection.ruleSet.rules.length}`);
     logger.info(`Applied disjunctively: ${collection.ruleSet.appliedDisjunctively}`);
 
@@ -38,8 +37,7 @@ class CollectionRuleSetHandler {
     );
 
     if (metafieldConditions.length > 0) {
-      logger.info(`Collection has ${metafieldConditions.length} metafield conditions in its rule set`);
-      logger.indent();
+      logger.startSection(`Collection has ${metafieldConditions.length} metafield conditions in its rule set`);
 
       // Check if conditionObject is present for any rules
       const hasConditionObject = metafieldConditions.some(rule => rule.conditionObject);
@@ -50,8 +48,7 @@ class CollectionRuleSetHandler {
 
       // Log each metafield condition for diagnosis purposes only
       metafieldConditions.forEach((rule, index) => {
-        logger.info(`Rule ${index + 1}: ${rule.column}`);
-        logger.indent();
+        logger.startSection(`Rule ${index + 1}: ${rule.column}`);
 
         if (!rule.conditionObject) {
           logger.error(`Metafield rule ${index + 1} is missing conditionObject`);
@@ -91,13 +88,13 @@ class CollectionRuleSetHandler {
           logger.error(`✗ No matching definition found for ${def.namespace}.${def.key} with ownerType=${def.ownerType}`);
         }
 
-        logger.unindent();
+        logger.endSection();
       });
 
-      logger.unindent();
+      logger.endSection();
     }
 
-    logger.unindent();
+    logger.endSection();
     return metafieldConditions.length > 0;
   }
 
@@ -175,8 +172,7 @@ class CollectionRuleSetHandler {
     );
 
     if (metafieldRules.length > 0) {
-      logger.info(`Smart collection uses ${metafieldRules.length} metafield conditions in its rules`);
-      logger.indent();
+      logger.startSection(`Smart collection uses ${metafieldRules.length} metafield conditions in its rules`);
 
       for (const rule of metafieldRules) {
         if (!rule.conditionObject || !rule.conditionObject.metafieldDefinition) {
@@ -190,8 +186,7 @@ class CollectionRuleSetHandler {
           throw new Error(`Missing ownerType in metafield definition for collection ${collection.title}`);
         }
 
-        logger.info(`Metafield rule: ${def.namespace}.${def.key}`);
-        logger.indent();
+        logger.startSection(`Metafield rule: ${def.namespace}.${def.key}`);
         logger.info(`Owner type: ${def.ownerType}`);
         logger.info(`Relation: ${rule.relation}`);
         logger.info(`Condition: ${rule.condition}`);
@@ -199,10 +194,10 @@ class CollectionRuleSetHandler {
         // These would use a special CollectionRuleMetafieldCondition type in Shopify GraphQL
         logger.info(`⚠ This collection uses metafield conditions which may require specific metafield definitions`);
         logger.info(`  with the MetafieldCapabilitySmartCollectionCondition capability for owner type: ${def.ownerType}`);
-        logger.unindent();
+        logger.endSection();
       }
 
-      logger.unindent();
+      logger.endSection();
     }
   }
 
@@ -220,8 +215,7 @@ class CollectionRuleSetHandler {
     );
 
     if (metafieldRules.length > 0) {
-      logger.error(`Smart collection uses metafield rules:`);
-      logger.indent();
+      logger.startSection(`Smart collection uses metafield rules:`);
 
       metafieldRules.forEach((rule, index) => {
         if (rule.conditionObject && rule.conditionObject.metafieldDefinition) {
@@ -241,7 +235,7 @@ class CollectionRuleSetHandler {
       logger.error(`3. The MetafieldCapabilitySmartCollectionCondition capability`);
       logger.error(`You can do this in Shopify Admin: Settings > Custom data > Product properties`);
 
-      logger.unindent();
+      logger.endSection();
     }
   }
 }

--- a/utils/ErrorHandler.js
+++ b/utils/ErrorHandler.js
@@ -18,10 +18,7 @@ class ErrorHandler {
     if (!userErrors || userErrors.length === 0) return 0;
 
     // Log the overall error message
-    logger.error(`Failed to process ${batchInfo}:`);
-
-    // Increase indentation for all error details
-    logger.indent();
+    logger.startSection(`Failed to process ${batchInfo}:`);
 
     // Handle each user error
     userErrors.forEach(err => {
@@ -42,9 +39,9 @@ class ErrorHandler {
               // Log value preview if available
               if (details.valuePreview) {
                 // Indent one more level for value preview
-                logger.indent();
+                logger.startSection();
                 logger.error(`Value: ${details.valuePreview}`);
-                logger.unindent();
+                logger.endSection();
               }
               return;
             }
@@ -60,7 +57,7 @@ class ErrorHandler {
     });
 
     // Reset indentation after error handling
-    logger.unindent();
+    logger.endSection();
 
     return userErrors.length;
   }

--- a/utils/MetafieldHandler.js
+++ b/utils/MetafieldHandler.js
@@ -26,10 +26,7 @@ class MetafieldHandler {
     if (!metafields || metafields.length === 0) return true;
 
     // Log how many metafields we're syncing - use main log type for bullet point
-    logger.info(`Syncing ${metafields.length} metafields for ID: ${ownerId}`, 'main');
-
-    // Increase indentation for all metafield processing
-    logger.indent();
+    logger.startSection(`Syncing ${metafields.length} metafields for ID: ${ownerId}`);
 
     // Split metafields into batches of 25 (Shopify limit per metafieldsSet mutation)
     const metafieldBatches = [];
@@ -48,8 +45,7 @@ class MetafieldHandler {
     // Process each batch
     for (let batchIndex = 0; batchIndex < metafieldBatches.length; batchIndex++) {
       const metafieldBatch = metafieldBatches[batchIndex];
-      logger.indent();
-      logger.info(`Processing batch ${batchIndex + 1}/${metafieldBatches.length} (${metafieldBatch.length} metafields)`);
+      logger.startSection(`Processing batch ${batchIndex + 1}/${metafieldBatches.length} (${metafieldBatch.length} metafields)`);
 
       // Prepare metafields inputs for this batch
       const metafieldsInput = metafieldBatch.map(metafield => ({
@@ -111,11 +107,11 @@ class MetafieldHandler {
 
             // Log individual metafields if debug is enabled
             if (this.debug) {
-              logger.indent();
+              logger.startSection();
               result.metafieldsSet.metafields.forEach(metafield => {
                 logger.debug(`Set metafield ${metafield.namespace}.${metafield.key}`);
               });
-              logger.unindent();
+              logger.endSection();
             }
           }
         } catch (error) {
@@ -127,27 +123,27 @@ class MetafieldHandler {
 
         // Log individual metafields if debug is enabled
         if (this.debug) {
-          logger.indent();
+          logger.startSection();
           metafieldBatch.forEach(metafield => {
             logger.debug(`[DRY RUN] Would set metafield ${metafield.namespace}.${metafield.key}`);
           });
-          logger.unindent();
+          logger.endSection();
         }
       }
 
-      // Unindent after batch processing
-      logger.unindent();
+      // End batch section
+      logger.endSection();
     }
 
     // Return success status
     if (this.options.notADrill) {
       logger.info(`Metafields sync complete: ${successCount} successful, ${failedCount} failed`);
       // Unindent after all metafield processing
-      logger.unindent();
+      logger.endSection();
       return failedCount === 0;
     } else {
       // Unindent after all metafield processing
-      logger.unindent();
+      logger.endSection();
       return true;
     }
   }

--- a/utils/MetafieldReferenceHandler.js
+++ b/utils/MetafieldReferenceHandler.js
@@ -62,10 +62,7 @@ class MetafieldReferenceHandler {
     };
 
     // Log the start of reference transformation
-    logger.info(`Starting reference transformation for ${metafields.length} metafields`);
-
-    // Indent all subsequent logs within the transformation process
-    logger.indent();
+    logger.startSection(`Starting reference transformation for ${metafields.length} metafields`);
 
     for (const metafield of metafields) {
       // Skip if no type (shouldn't happen)
@@ -177,8 +174,8 @@ class MetafieldReferenceHandler {
       `${refCount} single references, ${listCount} list references, ` +
       `${stats.blanked} blanked due to errors, ${unsupportedCount} unsupported types`);
 
-    // Unindent before returning
-    logger.unindent();
+    // End transformation section
+    logger.endSection();
 
     return {
       transformedMetafields,
@@ -335,7 +332,7 @@ class MetafieldReferenceHandler {
       logger.info(`Found ${sourceIds.length} source ${refType} IDs in list`);
 
       // Increase indentation for all ID processing
-      logger.indent();
+      logger.startSection();
 
       const targetIds = [];
 
@@ -416,7 +413,7 @@ class MetafieldReferenceHandler {
       }
 
       // Decrease indentation after processing all IDs
-      logger.unindent();
+      logger.endSection();
 
       if (targetIds.length > 0) {
         const transformedValue = JSON.stringify(targetIds);

--- a/utils/MetaobjectDefinitionHandler.js
+++ b/utils/MetaobjectDefinitionHandler.js
@@ -362,16 +362,14 @@ class MetaobjectDefinitionHandler {
     }
 
     logger.info(``);
-    logger.info(`Available metaobject definition types:`);
-
-    logger.indent();
+    logger.startSection(`Available metaobject definition types:`);
 
     definitions.forEach((def) => {
       logger.info(`${def.type} (${def.name || "No name"})`, 0, "main");
     });
 
     logger.info(``);
-    logger.unindent();
+    logger.endSection();
 
     logger.info(`Please run the command again with --key <type> to specify which metaobject type to sync.`);
   }

--- a/utils/ProductMetafieldProcessor.js
+++ b/utils/ProductMetafieldProcessor.js
@@ -39,7 +39,7 @@ class ProductMetafieldProcessor {
     // Print each transformed metafield for debugging
     if (this.debug) {
       // Increase indentation for debug details
-      logger.indent();
+      logger.startSection();
 
       transformedMetafields.forEach(metafield => {
         // Skip logging blanked metafields
@@ -61,7 +61,7 @@ class ProductMetafieldProcessor {
       });
 
       // Reset indentation after debug details
-      logger.unindent();
+      logger.endSection();
     }
 
     await this.metafieldHandler.syncMetafields(productId, transformedMetafields);

--- a/utils/ProductOperationHandler.js
+++ b/utils/ProductOperationHandler.js
@@ -107,7 +107,7 @@ class ProductOperationHandler {
       logger.info(`[DRY RUN] Would create product "${product.title}"`, 'main');
 
       // Indent dry run details
-      logger.indent();
+      logger.startSection();
       logger.info(`[DRY RUN] Would create ${product.variants ? product.variants.length : 0} variant(s)`);
       logger.info(`[DRY RUN] Would sync ${product.images ? product.images.length : 0} image(s) and ${product.metafields ? product.metafields.length : 0} metafield(s)`);
 
@@ -119,7 +119,7 @@ class ProductOperationHandler {
       }
 
       // Unindent after dry run details
-      logger.unindent();
+      logger.endSection();
 
       return {
         id: "dry-run-id",
@@ -225,7 +225,7 @@ class ProductOperationHandler {
       logger.info(`[DRY RUN] Would update product "${product.title}"`, 'main');
 
       // Indent dry run details
-      logger.indent();
+      logger.startSection();
       logger.info(`[DRY RUN] Would update ${product.variants ? product.variants.length : 0} variant(s)`);
       logger.info(`[DRY RUN] Would sync ${product.images ? product.images.length : 0} image(s) and ${product.metafields ? product.metafields.length : 0} metafield(s)`);
 
@@ -237,7 +237,7 @@ class ProductOperationHandler {
       }
 
       // Unindent after dry run details
-      logger.unindent();
+      logger.endSection();
 
       return {
         id: existingProduct.id,

--- a/utils/ProductPublicationHandler.js
+++ b/utils/ProductPublicationHandler.js
@@ -73,10 +73,7 @@ class ProductPublicationHandler {
       );
     }
 
-    logger.info(`Syncing product publication to ${publicationsToProcess.length} channels`);
-
-    // Increase indentation for publication operations
-    logger.indent();
+    logger.startSection(`Syncing product publication to ${publicationsToProcess.length} channels`);
 
     // First, get available channels and publications in the target store
     const getPublicationsQuery = `#graphql
@@ -120,7 +117,7 @@ class ProductPublicationHandler {
       }
     } catch (error) {
       logger.error(`Error fetching target store publications: ${error.message}`);
-      logger.unindent();
+      logger.endSection();
       return false;
     }
 
@@ -225,7 +222,7 @@ class ProductPublicationHandler {
     // If no publications to create, we're done
     if (publicationsToCreate.length === 0) {
       logger.info(`No new publication channels to add`);
-      logger.unindent();
+      logger.endSection();
       return true;
     }
 
@@ -258,25 +255,25 @@ class ProductPublicationHandler {
 
         if (result.publishablePublish.userErrors.length > 0) {
           logger.error(`Failed to publish product:`, result.publishablePublish.userErrors);
-          logger.unindent();
+          logger.endSection();
           return false;
         }
 
         logger.success(`Successfully published product to ${publicationsToCreate.length} channels`);
 
-        // Unindent before returning
-        logger.unindent();
+        // End publish section before returning
+        logger.endSection();
         return true;
       } catch (error) {
         logger.error(`Error publishing product: ${error.message}`);
-        logger.unindent();
+        logger.endSection();
         return false;
       }
     } else {
       logger.info(`[DRY RUN] Would publish product to ${publicationsToCreate.length} channels: ${publicationsToCreate.map(p => p.channelHandle).join(', ')}`);
 
-      // Unindent before returning
-      logger.unindent();
+      // End publish section before returning
+      logger.endSection();
       return true;
     }
   }

--- a/utils/collection/CollectionOperationHandler.js
+++ b/utils/collection/CollectionOperationHandler.js
@@ -423,8 +423,7 @@ class CollectionOperationHandler {
   }
 
   _logOperationErrors(operation, collectionTitle, errors) {
-    logger.error(`Failed to ${operation} collection "${collectionTitle}":`);
-    logger.indent();
+    logger.startSection(`Failed to ${operation} collection "${collectionTitle}":`);
 
     // Check for metafield definition errors
     const metafieldErrors = errors.filter(err =>
@@ -435,8 +434,7 @@ class CollectionOperationHandler {
     );
 
     if (metafieldErrors.length > 0) {
-      logger.error(`Metafield Definition Errors:`);
-      logger.indent();
+      logger.startSection(`Metafield Definition Errors:`);
 
       // If collection has metafields, try to log which one is causing problems
       if (this.lastProcessedCollection && this.lastProcessedCollection.metafields) {
@@ -444,8 +442,7 @@ class CollectionOperationHandler {
           ? this.lastProcessedCollection.metafields.edges.map(edge => edge.node)
           : this.lastProcessedCollection.metafields;
 
-        logger.error(`Collection has the following metafields:`);
-        logger.indent();
+        logger.startSection(`Collection has the following metafields:`);
 
         metafields.forEach(metafield => {
           if (metafield.namespace && metafield.key) {
@@ -454,7 +451,7 @@ class CollectionOperationHandler {
           }
         });
 
-        logger.unindent();
+        logger.endSection();
 
         // Check for metafield conditions in rule set
         if (this.lastProcessedCollection.ruleSet && this.lastProcessedCollection.ruleSet.rules && this.ruleSetHandler) {
@@ -465,12 +462,11 @@ class CollectionOperationHandler {
         logger.error(`Could not find metafield information for this collection.`);
       }
 
-      logger.unindent();
+      logger.endSection();
     }
 
     // Log errors with proper formatting
-    logger.error(`API Errors:`);
-    logger.indent();
+    logger.startSection(`API Errors:`);
 
     errors.forEach(err => {
       if (err.field) {
@@ -483,8 +479,8 @@ class CollectionOperationHandler {
       }
     });
 
-    logger.unindent();
-    logger.unindent();
+    logger.endSection();
+    logger.endSection();
   }
 
   prepareMetafields(collection) {

--- a/utils/collection/CollectionProductHandler.js
+++ b/utils/collection/CollectionProductHandler.js
@@ -232,8 +232,7 @@ class CollectionProductHandler {
    * @returns {Boolean} Success status
    */
   async syncCollectionProducts(sourceCollectionId, targetCollectionId) {
-    logger.info(`Syncing products between collections`);
-    logger.indent();
+    logger.startSection(`Syncing products between collections`);
 
     // Fetch products from source collection
     const sourceProducts = await this.fetchCollectionProducts(
@@ -244,7 +243,7 @@ class CollectionProductHandler {
 
     if (sourceProducts.length === 0) {
       logger.info(`No products found in source collection`);
-      logger.unindent();
+      logger.endSection();
       return true;
     }
 
@@ -311,7 +310,7 @@ class CollectionProductHandler {
 
     if (productsToAdd.length === 0) {
       logger.info(`All products are already in the target collection - nothing to add`);
-      logger.unindent();
+      logger.endSection();
       return true;
     }
 
@@ -320,11 +319,11 @@ class CollectionProductHandler {
     // Add products to the target collection
     if (productsToAdd.length > 0) {
       const success = await this.addProductsToCollection(targetCollectionId, productsToAdd);
-      logger.unindent();
+      logger.endSection();
       return success;
     } else {
       logger.warn(`No matching products found in target shop to add to collection`);
-      logger.unindent();
+      logger.endSection();
       return true;
     }
   }

--- a/utils/collection/CollectionPublicationHandler.js
+++ b/utils/collection/CollectionPublicationHandler.js
@@ -82,8 +82,7 @@ class CollectionPublicationHandler {
       return true;
     }
 
-    logger.info(`Syncing collection publication to ${validPublications.length} channels`);
-    logger.indent();
+    logger.startSection(`Syncing collection publication to ${validPublications.length} channels`);
 
     // Get current publications for this collection
     const getCollectionPublicationsQuery = `#graphql
@@ -180,7 +179,7 @@ class CollectionPublicationHandler {
     // If no publications to create, we're done
     if (publicationsToCreate.length === 0) {
       logger.info(`No new publication channels to add`);
-      logger.unindent();
+      logger.endSection();
       return true;
     }
 
@@ -212,21 +211,21 @@ class CollectionPublicationHandler {
 
         if (result.publishablePublish.userErrors.length > 0) {
           logger.error(`Failed to publish collection:`, result.publishablePublish.userErrors);
-          logger.unindent();
+          logger.endSection();
           return false;
         }
 
         logger.success(`Successfully published collection to ${publicationsToCreate.length} channels`);
-        logger.unindent();
+        logger.endSection();
         return true;
       } catch (error) {
         logger.error(`Error publishing collection: ${error.message}`);
-        logger.unindent();
+        logger.endSection();
         return false;
       }
     } else {
       logger.info(`[DRY RUN] Would publish collection to ${publicationsToCreate.length} channels: ${publicationsToCreate.map(p => p.channelHandle).join(', ')}`);
-      logger.unindent();
+      logger.endSection();
       return true;
     }
   }

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -80,7 +80,7 @@ function log(message) {
  * Increase indentation level
  * @param {number} levels - Number of levels to indent (default: 1)
  */
-function indent(levels = 1) {
+function _indent(levels = 1) {
   indentLevel += levels;
   return indentLevel;
 }
@@ -89,7 +89,7 @@ function indent(levels = 1) {
  * Decrease indentation level
  * @param {number} levels - Number of levels to unindent (default: 1)
  */
-function unindent(levels = 1) {
+function _unindent(levels = 1) {
   indentLevel = Math.max(0, indentLevel - levels);
   return indentLevel;
 }
@@ -103,8 +103,10 @@ function debug(message) {
  * @param {number} levels - Number of levels to indent (default: 1)
  */
 function startSection(message, levels = 1) {
-  info(message);
-  return indent(levels);
+  if (message) {
+    info(message);
+  }
+  return _indent(levels);
 }
 
 function endSection(message, levels = 1) {
@@ -116,7 +118,7 @@ function endSection(message, levels = 1) {
     newline();
   }
 
-  unindent(levels);
+  _unindent(levels);
 }
 
 
@@ -172,7 +174,7 @@ function logProductAction(message, title, handle, type = 'update') {
  */
 function endProductAction() {
   // Unindent to return to the previous level
-  unindent();
+  _unindent();
 }
 
 /**
@@ -286,8 +288,6 @@ module.exports = {
   initializeLogFile,
   closeLogFile,
   getLogFilePath,
-  indent,
-  unindent,
   startSection,
   endSection,
   resetIndent,


### PR DESCRIPTION
## Summary
- hide `indent` and `unindent` behind private helpers
- replace direct indentation calls with `startSection`/`endSection`
- use `startSection` when listing available options
- update handlers and strategies to use new logger API

## Testing
- `npm test` *(fails: jest not found)*